### PR TITLE
Add exception for .github directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*
 !.gitignore
 !.travis.yml
+!.github
 
 target/


### PR DESCRIPTION
## What does this change?

It's currently impossible to add github actions to this repo due to `.gitginore` rule to ignore everything that starts with a `.`. This PR adds an exception for `.github`