### PR TITLE
Switch java version to 8

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -18,5 +18,6 @@ jobs:
       DEBUG: true
       ORG: guardian-devtools
       SKIP_NODE: true
+      JAVA_VERSION: 8
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?

Snyk action fails when calling sbt with the error

```
Error:  java.lang.AssertionError: assertion failed: Java 8 is required for this project.
Error:  Use 'last' for the full log.
```